### PR TITLE
debug/next.jsの開発サーバーが立ち上がらないバス開発サーバーが立ち上がらないバグシュウシェサーバーが立ち上がらないバグ修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,9 @@ services:
     volumes:
       - ./front/spe-con:/app
       - /app/node_modules
+ 
     ports:
-      - "8000:3000"
+      - "8080:8080"
  
 
 volumes:


### PR DESCRIPTION
## 目的
 - next.jsのローカルサーバーを立ち上げた際の「このページにはアクセスできません」というエラーをデバック
## やったこと
 - package.jsonでhttpsで開発環境にアクセスできるように修正しました
 - next.config.tsファイルの初期設定が古いバージョンの書き方だったので最新バージョンの書き方に修正
- Dockerfile.devで8080番ポートで開発環境が使われるように変更
## 注意事項
- 特にありません

